### PR TITLE
Add pagination parameters to API endpoint

### DIFF
--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -32,6 +32,11 @@ export async function GET(request: Request) {
   const token = request.headers.get("token");
   if (token !== process.env.API_TOKEN)
     return Response.json({ message: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(request.url);
+  const skip = parseInt(searchParams.get("skip") ?? "0", 10);
+  const limit = parseInt(searchParams.get("limit") ?? "15", 10);
+
   const res = await apolloClient.query<AssetCollectionApiQuery>({
     query: AssetCollectionApiDocument,
   });
@@ -45,7 +50,7 @@ export async function GET(request: Request) {
         width: item?.width ?? 0,
       };
     })
-    .slice(0, 15);
+    .slice(skip, skip + limit);
 
   return Response.json({
     total: res.data.assetCollection?.total ?? 0,


### PR DESCRIPTION
## Summary
- Add skip and limit URL parameters support to `/api` endpoint
- Maintain existing shuffle functionality with pagination support
- Default limit is 15 items, skip defaults to 0
- Enable paginated random results from API endpoint

## Test plan
- [ ] Test API endpoint with skip/limit parameters: `/api?skip=0&limit=10`
- [ ] Verify shuffle functionality is maintained
- [ ] Test default behavior without parameters
- [ ] Validate parameter parsing and bounds

🤖 Generated with [Claude Code](https://claude.ai/code)