### PR TITLE
Swap tab order and implement random-first navigation

### DIFF
--- a/src/app/components/Pagination.tsx
+++ b/src/app/components/Pagination.tsx
@@ -14,6 +14,10 @@ export const Pagination = ({
   if (totalPages <= 1) return null;
 
   const getPageHref = (page: number) => {
+    if (basePath === "/newest/pages") {
+      if (page === 1) return "/newest";
+      return `${basePath}/${page}`;
+    }
     if (page === 1) return "/";
     return `${basePath}/${page}`;
   };

--- a/src/app/components/TabNavigation.tsx
+++ b/src/app/components/TabNavigation.tsx
@@ -6,23 +6,14 @@ import { usePathname } from "next/navigation";
 export const TabNavigation = () => {
   const pathname = usePathname();
 
-  const isNewestActive = pathname === "/" || pathname.startsWith("/pages/");
-  const isRandomActive = pathname === "/random";
+  const isRandomActive = pathname === "/";
+  const isNewestActive =
+    pathname.startsWith("/newest") || pathname.startsWith("/pages/");
 
   return (
     <div className="flex rounded-lg bg-[#51381f4d] p-1 my-6 max-md:my-4">
       <Link
         href="/"
-        className={`rounded-md text-[#FCF0DE] text-xl max-md:text-lg px-6 py-3 max-md:px-4 max-md:py-2 flex items-center justify-center transition-all duration-300 ease-in-out ${
-          isNewestActive
-            ? "bg-[#59370F] shadow-sm"
-            : "hover:bg-[#59370F] hover:opacity-70"
-        }`}
-      >
-        新着順
-      </Link>
-      <Link
-        href="/random"
         className={`rounded-md text-[#FCF0DE] text-xl max-md:text-lg px-6 py-3 max-md:px-4 max-md:py-2 flex items-center justify-center transition-all duration-300 ease-in-out ${
           isRandomActive
             ? "bg-[#59370F] shadow-sm"
@@ -30,6 +21,16 @@ export const TabNavigation = () => {
         }`}
       >
         ランダム
+      </Link>
+      <Link
+        href="/newest"
+        className={`rounded-md text-[#FCF0DE] text-xl max-md:text-lg px-6 py-3 max-md:px-4 max-md:py-2 flex items-center justify-center transition-all duration-300 ease-in-out ${
+          isNewestActive
+            ? "bg-[#59370F] shadow-sm"
+            : "hover:bg-[#59370F] hover:opacity-70"
+        }`}
+      >
+        新着順
       </Link>
     </div>
   );

--- a/src/app/newest/page.tsx
+++ b/src/app/newest/page.tsx
@@ -1,0 +1,57 @@
+export const dynamic = "force-static";
+
+import { LgtmImage } from "@/app/components/LgtmImage";
+import {
+  AssetCollectionDocument,
+  type AssetCollectionQuery,
+  type QueryAssetCollectionArgs,
+} from "@/generated/schema";
+import { apolloClient } from "@/lib/apolloClient";
+import { Pagination } from "../components/Pagination";
+import { Snackbar } from "../components/Snackbar";
+import { TabNavigation } from "../components/TabNavigation";
+import { SIZE_PER_PAGE } from "../constants/sizePerPage";
+
+export default async function NewestPage() {
+  const res = await apolloClient.query<
+    AssetCollectionQuery,
+    QueryAssetCollectionArgs
+  >({
+    query: AssetCollectionDocument,
+    variables: {
+      skip: 0,
+      limit: SIZE_PER_PAGE,
+    },
+  });
+
+  const items = res.data.assetCollection?.items ?? [];
+  const totalCount = res.data.assetCollection?.total ?? 1;
+  const totalPage = Math.ceil(totalCount / SIZE_PER_PAGE);
+
+  return (
+    <main className="flex items-center m-auto flex-col max-w-[1240px] my-6 max-xl:mx-4 max-md:mx-2 relative">
+      <header className="my-4">
+        <img src="/title.svg" alt="Vercel Logo" width={360} height={100} />
+      </header>
+      <h2 className="text-xl max-md:text-base">
+        愛猫「らて」のLGTM画像を集めました。LGTMする際にお使いください。
+      </h2>
+
+      <TabNavigation />
+
+      <div className="grid grid-cols-3 gap-8 max-xl:grid-cols-3 max-lg:grid-cols-2 max-md:grid-cols-1 max-md:gap-4 mt-4 mb-16 max-md:mb-8 w-full">
+        {items.map((item) => (
+          <div key={item?.title} className="h-auto max-h-96 w-auto relative">
+            <LgtmImage url={item?.url ?? ""} />
+          </div>
+        ))}
+      </div>
+      <Snackbar />
+      <Pagination
+        currentPage={1}
+        totalPages={totalPage}
+        basePath="/newest/pages"
+      />
+    </main>
+  );
+}

--- a/src/app/newest/pages/[page]/page.tsx
+++ b/src/app/newest/pages/[page]/page.tsx
@@ -1,0 +1,78 @@
+export const dynamic = "force-static";
+
+import { LgtmImage } from "@/app/components/LgtmImage";
+import { Pagination } from "@/app/components/Pagination";
+import { Snackbar } from "@/app/components/Snackbar";
+import { TabNavigation } from "@/app/components/TabNavigation";
+import { SIZE_PER_PAGE } from "@/app/constants/sizePerPage";
+import {
+  AssetCollectionDocument,
+  AssetCollectionTotalDocument,
+  type AssetCollectionTotalQuery,
+  type Query,
+  type QueryAssetCollectionArgs,
+} from "@/generated/schema";
+import { apolloClient } from "@/lib/apolloClient";
+
+export const generateStaticParams = async () => {
+  const res = await apolloClient.query<
+    AssetCollectionTotalQuery,
+    QueryAssetCollectionArgs
+  >({
+    query: AssetCollectionTotalDocument,
+  });
+
+  const totalCount = res.data.assetCollection?.total ?? 0;
+
+  const totalPage = Math.ceil(totalCount / SIZE_PER_PAGE);
+  const paths = Array.from({ length: totalPage }).map((_, i) => ({
+    page: (i + 1).toString(),
+  }));
+  return paths;
+};
+
+export default async function NewestPaginatedPage({
+  params,
+}: {
+  params: { page: string; totalPage: string };
+}) {
+  const res = await apolloClient.query<Query, QueryAssetCollectionArgs>({
+    query: AssetCollectionDocument,
+    variables: {
+      skip: SIZE_PER_PAGE * (parseInt(params.page) - 1),
+      limit: SIZE_PER_PAGE,
+    },
+  });
+
+  const items = res.data.assetCollection?.items ?? [];
+  const totalCount = res.data.assetCollection?.total ?? 0;
+  const totalPage = Math.ceil(totalCount / SIZE_PER_PAGE);
+  const page = Number(params.page);
+
+  return (
+    <main className="flex items-center m-auto flex-col max-w-[1240px] my-6 max-xl:mx-4 max-md:mx-2 relative">
+      <header className="my-4">
+        <img src="/title.svg" alt="Vercel Logo" width={360} height={100} />
+      </header>
+      <h2 className="text-xl max-md:text-base">
+        愛猫「らて」のLGTM画像を集めました。LGTMする際にお使いください。
+      </h2>
+
+      <TabNavigation />
+
+      <div className="grid grid-cols-3 gap-8 max-xl:grid-cols-3 max-lg:grid-cols-2 max-md:grid-cols-1 max-md:gap-4 mt-4 mb-16 max-md:mb-8 w-full">
+        {items.map((item) => (
+          <div key={item?.title} className="h-auto max-h-96 w-auto relative">
+            <LgtmImage url={item?.url ?? ""} />
+          </div>
+        ))}
+      </div>
+      <Snackbar />
+      <Pagination
+        currentPage={page}
+        totalPages={totalPage}
+        basePath="/newest/pages"
+      />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,32 +1,47 @@
-export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
 
-import { LgtmImage } from "@/app/components/LgtmImage";
-import {
-  AssetCollectionDocument,
-  type AssetCollectionQuery,
-  type QueryAssetCollectionArgs,
-} from "@/generated/schema";
-import { apolloClient } from "@/lib/apolloClient";
-import { Pagination } from "./components/Pagination";
-import { Snackbar } from "./components/Snackbar";
-import { TabNavigation } from "./components/TabNavigation";
-import { SIZE_PER_PAGE } from "./constants/sizePerPage";
+import { RandomImages } from "@/app/components/RandomImages";
+import { Snackbar } from "@/app/components/Snackbar";
+import { TabNavigation } from "@/app/components/TabNavigation";
+
+interface ImageData {
+  url: string;
+  title: string;
+  width: number;
+}
+
+interface ApiResponse {
+  total: number;
+  images: ImageData[];
+}
+
+async function getInitialImages(): Promise<ApiResponse> {
+  const apiUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+
+  try {
+    const response = await fetch(`${apiUrl}/api?skip=0&limit=15`, {
+      headers: {
+        token: process.env.API_TOKEN || "",
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Failed to fetch initial images:", error);
+    return {
+      total: 0,
+      images: [],
+    };
+  }
+}
 
 export default async function Home() {
-  const res = await apolloClient.query<
-    AssetCollectionQuery,
-    QueryAssetCollectionArgs
-  >({
-    query: AssetCollectionDocument,
-    variables: {
-      skip: 0,
-      limit: SIZE_PER_PAGE,
-    },
-  });
-
-  const items = res.data.assetCollection?.items ?? [];
-  const totalCount = res.data.assetCollection?.total ?? 1;
-  const totalPage = Math.ceil(totalCount / SIZE_PER_PAGE);
+  const data = await getInitialImages();
 
   return (
     <main className="flex items-center m-auto flex-col max-w-[1240px] my-6 max-xl:mx-4 max-md:mx-2 relative">
@@ -39,15 +54,9 @@ export default async function Home() {
 
       <TabNavigation />
 
-      <div className="grid grid-cols-3 gap-8 max-xl:grid-cols-3 max-lg:grid-cols-2 max-md:grid-cols-1 max-md:gap-4 mt-4 mb-16 max-md:mb-8 w-full">
-        {items.map((item) => (
-          <div key={item?.title} className="h-auto max-h-96 w-auto relative">
-            <LgtmImage url={item?.url ?? ""} />
-          </div>
-        ))}
-      </div>
+      <RandomImages initialImages={data.images} />
+
       <Snackbar />
-      <Pagination currentPage={1} totalPages={totalPage} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Switch tab order to Random (left) and Newest (right) for improved UX
- Change home page (/) to display random images by default
- Create /newest route with pagination for newest images
- Update all routing logic and path handling

## Changes
- **TabNavigation**: Swap tab order and update path logic
- **Home page (/)**: Now displays random images with infinite scroll
- **New /newest route**: Displays paginated newest images (first page)
- **New /newest/pages/[page]**: Handles pagination for newest images
- **Pagination component**: Enhanced to handle /newest basePath routing

## Test plan
- [ ] Verify home page (/) shows random images with Random tab active
- [ ] Test /newest shows newest images with Newest tab active
- [ ] Check pagination works correctly on /newest/pages/2, /newest/pages/3, etc.
- [ ] Confirm tab highlighting works properly on all routes
- [ ] Test navigation between Random and Newest views

🤖 Generated with [Claude Code](https://claude.ai/code)